### PR TITLE
delete UTF-8 if you don't need it

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -8,7 +8,6 @@
       <SourcesRoot>src</SourcesRoot>
       <Resource Name="diashenrique.messageviewer.MessageViewer.cls"/>
       <Resource Name="diashenrique.messageviewer.util.InstallerProduction.cls"/>
-      <SystemSetting Name="CSP.DefaultFileCharset" Value="UTF-8"/>
       <CSPApplication
         Url="/csp/msgviewer"
         Path="/src/csp"


### PR DESCRIPTION
If you don't need this: <SystemSetting Name="CSP.DefaultFileCharset" Value="UTF-8"/>
let's get rid, cause it doesn't allow some packages coexist